### PR TITLE
[Refactor] Redesign of welcome and tutorial screens for low and high resolution devices

### DIFF
--- a/app/src/main/res/layout/fragment_start.xml
+++ b/app/src/main/res/layout/fragment_start.xml
@@ -1,79 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:background="@color/darkBrown1"
-    tools:context="galilel.org.galilelwallet.ui.base.BaseDrawerActivity">
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:paddingTop="50dp"
+	android:orientation="vertical"
+	android:gravity="center_horizontal"
+	android:background="@color/darkBrown1"
+	tools:context="galilel.org.galilelwallet.ui.base.BaseDrawerActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop = "true"
-        android:layout_centerHorizontal = "true"
-        android:orientation="vertical">
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:src="@mipmap/img_login_logo" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/logoView"
-            android:src="@mipmap/img_login_logo"
-            android:paddingTop="40dp"
-            android:paddingBottom="20dp"
-            android:layout_gravity="center" />
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/tutorial_message"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAlignment="center" />
 
-        <TextView
-            android:id="@+id/tutorialMessage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/tutorial_message"
-            android:textColor="@color/galilelWhite"
-            android:textSize="18sp"
-            android:paddingTop="40dp"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp" />
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_weight="1"
+		android:paddingLeft="@dimen/activity_horizontal_margin"
+		android:paddingRight="@dimen/activity_horizontal_margin"
+		android:paddingTop="@dimen/activity_vertical_margin"
+		android:paddingBottom="@dimen/activity_vertical_margin"
+		android:orientation="vertical"
+		android:gravity="bottom">
 
-    </LinearLayout>
+		<Button
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:paddingBottom="12dp"
+			android:paddingTop="12dp"
+			android:text="@string/btn_create_wallet"
+			android:textColor="@color/darkBrown1"
+			android:textSize="15sp"
+			android:background="@drawable/button_white"
+			android:id="@+id/btnCreate" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true">
+		<Button
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="7dp"
+			android:paddingBottom="12dp"
+			android:paddingTop="12dp"
+			android:text="@string/btn_restore_wallet"
+			android:textSize="15sp"
+			android:textColor="@color/galilelWhite"
+			android:background="@android:color/transparent"
+			android:id="@+id/btnRestore" />
 
-        <Button
-            android:id="@+id/btnCreate"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical|center_horizontal"
-            android:background="@drawable/button_white"
-            android:text="@string/btn_create_wallet"
-            android:paddingBottom="12dp"
-            android:paddingTop="12dp"
-            android:stateListAnimator="@null"
-            android:textColor="@color/darkBrown1"
-            android:textSize="14sp" />
+	</LinearLayout>
 
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
-            android:paddingBottom="12dp"
-            android:paddingTop="12dp"
-            android:gravity="center_vertical|center_horizontal"
-            android:background="@android:color/transparent"
-            android:text="@string/btn_restore_wallet"
-            android:id="@+id/btnRestore"
-            android:textSize="14sp"
-            android:textColor="@color/galilelWhite" />
-
-    </LinearLayout>
-
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/tutorial_activity.xml
+++ b/app/src/main/res/layout/tutorial_activity.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/activity_intro"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.tutorial_activity.TutorialActivity">
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	tools:context=".ui.tutorial_activity.TutorialActivity">
 
-    <android.support.v4.view.ViewPager
-        android:id="@+id/view_pager"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+	<android.support.v4.view.ViewPager
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:id="@+id/view_pager" />
 
-    <LinearLayout
-        android:id="@+id/layoutDots"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/dots_height"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="@dimen/dots_bottom_margin"
-        android:gravity="center"
-        android:orientation="horizontal" />
+	<View
+		android:layout_width="match_parent"
+		android:layout_height="1dp"
+		android:layout_above="@id/layoutDots"
+		android:alpha=".5"
+		android:background="@color/galilelWhite" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:alpha=".5"
-        android:layout_above="@id/layoutDots"
-        android:background="@color/galilelWhite" />
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/pager_height"
+		android:layout_alignParentBottom="true"
+		android:orientation="horizontal"
+		android:gravity="center"
+		android:id="@+id/layoutDots">
 
-    <Button
-        android:id="@+id/btn_next"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:background="@null"
-        android:text="@string/next"
-        android:onClick="btnNextClick"
-        android:textColor="@color/galilelWhite" />
+	</LinearLayout>
 
     <Button
-        android:id="@+id/btn_skip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:background="@null"
-        android:text="@string/skip"
-        android:onClick="btnSkipClick"
-        android:textColor="@color/galilelWhite" />
+		android:layout_width="wrap_content"
+		android:layout_height="@dimen/pager_height"
+		android:paddingLeft="@dimen/activity_horizontal_margin"
+		android:paddingRight="@dimen/activity_horizontal_margin"
+		android:layout_alignParentBottom="true"
+		android:layout_alignParentLeft="true"
+		android:text="@string/skip"
+		android:textColor="@color/galilelWhite"
+		android:onClick="btnSkipClick"
+		android:id="@+id/btn_skip" />
+
+	<Button
+		android:layout_width="wrap_content"
+		android:layout_height="@dimen/pager_height"
+		android:paddingLeft="@dimen/activity_horizontal_margin"
+		android:paddingRight="@dimen/activity_horizontal_margin"
+		android:layout_alignParentBottom="true"
+		android:layout_alignParentRight="true"
+		android:text="@string/next"
+		android:textColor="@color/galilelWhite"
+		android:onClick="btnNextClick"
+		android:id="@+id/btn_next" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide1.xml
+++ b/app/src/main/res/layout/tutorial_slide1.xml
@@ -40,7 +40,6 @@
 
 	<View
 		android:layout_width="match_parent"
-		android:layout_height="@dimen/dots_height"
-		android:layout_marginBottom="@dimen/dots_bottom_margin" />
+		android:layout_height="@dimen/pager_height" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide1.xml
+++ b/app/src/main/res/layout/tutorial_slide1.xml
@@ -1,55 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="100dp"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:background="@color/darkBrown1">
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:paddingTop="50dp"
+	android:orientation="vertical"
+	android:gravity="center_horizontal"
+	android:background="@color/darkBrown1">
 
-        <ImageView
-            android:id="@+id/tutorialImage"
-            android:layout_alignParentTop = "true"
-            android:layout_centerHorizontal = "true"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/img_step_1" />
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:src="@drawable/img_step_1" />
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="70dp"
-            android:gravity="center_horizontal"
-            android:orientation="vertical"
-            android:layout_below="@+id/tutorialImage"
-            android:layout_alignParentStart="true">
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/title_slide1"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAllCaps="true"
+		android:textStyle="bold" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/title_slide1"
-                android:paddingLeft="16dp"
-                android:paddingRight="16dp"
-                android:gravity="center"
-                android:layout_gravity="center"
-                android:textColor="@color/galilelWhite"
-                android:textSize="@dimen/text_title"
-                android:textAllCaps="true"
-                android:textStyle="bold" />
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/desc_slide1"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAlignment="center" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:paddingLeft="16dp"
-                android:gravity="center"
-                android:layout_gravity="center"
-                android:paddingRight="16dp"
-                android:text="@string/desc_slide1"
-                android:textAlignment="center"
-                android:textColor="@color/galilelWhite"
-                android:textSize="@dimen/text_title" />
-        </LinearLayout>
+	<View
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dots_height"
+		android:layout_marginBottom="@dimen/dots_bottom_margin" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide2.xml
+++ b/app/src/main/res/layout/tutorial_slide2.xml
@@ -1,56 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="100dp"
-    android:paddingBottom="100dp"
-    android:background="@color/darkBrown1">
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:paddingTop="50dp"
+	android:orientation="vertical"
+	android:gravity="center_horizontal"
+	android:background="@color/darkBrown1">
 
-    <ImageView
-        android:id="@+id/tutorialImage"
-        android:layout_alignParentTop = "true"
-        android:layout_centerHorizontal = "true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/img_step_2" />
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:src="@drawable/img_step_2" />
 
-    <LinearLayout
-        android:layout_below="@+id/tutorialImage"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_centerInParent="true"
-        android:paddingTop="70dp"
-        android:gravity="center_horizontal"
-        android:orientation="vertical">
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/title_slide2"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAllCaps="true"
+		android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:layout_gravity="center"
-            android:text="@string/title_slide2"
-            android:textColor="@color/galilelWhite"
-            android:textAllCaps="true"
-            android:textSize="@dimen/text_title"
-            android:textStyle="bold" />
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/desc_slide2"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAlignment="center" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="20dp"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:gravity="center"
-            android:layout_gravity="center"
-            android:text="@string/desc_slide2"
-            android:textAlignment="center"
-            android:textColor="@color/galilelWhite"
-            android:textSize="@dimen/text_title" />
+	<View
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dots_height"
+		android:layout_marginBottom="@dimen/dots_bottom_margin" />
 
-    </LinearLayout>
-
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide2.xml
+++ b/app/src/main/res/layout/tutorial_slide2.xml
@@ -40,7 +40,6 @@
 
 	<View
 		android:layout_width="match_parent"
-		android:layout_height="@dimen/dots_height"
-		android:layout_marginBottom="@dimen/dots_bottom_margin" />
+		android:layout_height="@dimen/pager_height" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide3.xml
+++ b/app/src/main/res/layout/tutorial_slide3.xml
@@ -1,56 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="100dp"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:background="@color/darkBrown1">
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:paddingTop="50dp"
+	android:orientation="vertical"
+	android:gravity="center_horizontal"
+	android:background="@color/darkBrown1">
 
-    <ImageView
-        android:id="@+id/tutorialImage"
-        android:layout_alignParentTop = "true"
-        android:layout_centerHorizontal = "true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/img_step_3" />
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:src="@drawable/img_step_3" />
 
-    <LinearLayout
-        android:layout_below="@+id/tutorialImage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="70dp"
-        android:layout_centerInParent="true"
-        android:gravity="center_horizontal"
-        android:orientation="vertical">
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/title_slide3"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAllCaps="true"
+		android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/title_slide3"
-            android:textAllCaps="true"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:gravity="center"
-            android:layout_gravity="center"
-            android:textColor="@color/galilelWhite"
-            android:textSize="@dimen/text_title"
-            android:textStyle="bold" />
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/desc_slide3"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAlignment="center" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:paddingLeft="16dp"
-            android:gravity="center"
-            android:layout_gravity="center"
-            android:paddingRight="16dp"
-            android:text="@string/desc_slide3"
-            android:textAlignment="center"
-            android:textColor="@color/galilelWhite"
-            android:textSize="@dimen/text_title" />
+	<View
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dots_height"
+		android:layout_marginBottom="@dimen/dots_bottom_margin" />
 
-    </LinearLayout>
-
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide3.xml
+++ b/app/src/main/res/layout/tutorial_slide3.xml
@@ -40,7 +40,6 @@
 
 	<View
 		android:layout_width="match_parent"
-		android:layout_height="@dimen/dots_height"
-		android:layout_marginBottom="@dimen/dots_bottom_margin" />
+		android:layout_height="@dimen/pager_height" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide4.xml
+++ b/app/src/main/res/layout/tutorial_slide4.xml
@@ -62,7 +62,6 @@
 
 	<View
 		android:layout_width="match_parent"
-		android:layout_height="@dimen/dots_height"
-		android:layout_marginBottom="@dimen/dots_bottom_margin" />
+		android:layout_height="@dimen/pager_height" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tutorial_slide4.xml
+++ b/app/src/main/res/layout/tutorial_slide4.xml
@@ -1,76 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="100dp"
-    android:paddingBottom="60dp"
-    android:background="@color/darkBrown1">
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:paddingTop="50dp"
+	android:orientation="vertical"
+	android:gravity="center_horizontal"
+	android:background="@color/darkBrown1">
 
-    <ImageView
-        android:id="@+id/tutorialImage"
-        android:layout_alignParentTop = "true"
-        android:layout_centerHorizontal = "true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/img_step_4" />
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:src="@drawable/img_step_4" />
 
-    <LinearLayout
-        android:layout_below="@+id/tutorialImage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="70dp"
-        android:layout_centerInParent="true"
-        android:gravity="center_horizontal"
-        android:orientation="vertical">
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/title_slide4"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAllCaps="true"
+		android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/title_slide4"
-            android:textAllCaps="true"
-            android:textColor="@color/galilelWhite"
-            android:textSize="@dimen/text_title"
-            android:textStyle="bold" />
+	<TextView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:paddingLeft="16dp"
+		android:paddingRight="16dp"
+		android:paddingTop="8dp"
+		android:paddingBottom="8dp"
+		android:text="@string/desc_slide4"
+		android:textColor="@color/galilelWhite"
+		android:textSize="@dimen/text_title"
+		android:textAlignment="center" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="20dp"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:text="@string/desc_slide4"
-            android:textAlignment="center"
-            android:textColor="@color/galilelWhite"
-            android:textSize="@dimen/text_title" />
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_weight="1"
+		android:paddingLeft="@dimen/activity_horizontal_margin"
+		android:paddingRight="@dimen/activity_horizontal_margin"
+		android:paddingTop="@dimen/activity_vertical_margin"
+		android:paddingBottom="@dimen/activity_vertical_margin"
+		android:orientation="vertical"
+		android:gravity="bottom">
 
-    </LinearLayout>
+		<Button
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:text="@string/btn_select_node"
+			android:textColor="@color/darkBrown1"
+			android:textSize="15sp"
+			android:background="@drawable/button_white"
+			android:onClick="btnNodeClick" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:paddingBottom="@dimen/activity_vertical_margin">
+	</LinearLayout>
 
-        <Button
-            android:id="@+id/btn_node"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="12dp"
-            android:paddingTop="12dp"
-            android:gravity="center_vertical|center_horizontal"
-            android:background="@drawable/button_white"
-            android:text="@string/btn_select_node"
-            android:textColor="@color/darkBrown1"
-            android:textSize="15sp"
-            android:onClick="btnNodeClick" />
+	<View
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dots_height"
+		android:layout_marginBottom="@dimen/dots_bottom_margin" />
 
-    </LinearLayout>
-
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,8 +21,6 @@
 	<dimen name="text_title">18sp</dimen>
 
 	<!-- Tutorial -->
-	<dimen name="dots_height">30dp</dimen>
-	<dimen name="dots_bottom_margin">20dp</dimen>
 	<dimen name="pager_height">50dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,31 +1,28 @@
 <resources>
 
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="nav_header_vertical_spacing">12dp</dimen>
-    <dimen name="nav_header_height">160dp</dimen>
-    <dimen name="fab_margin">16dp</dimen>
-    <dimen name="padding_list_row">16dp</dimen>
-    <dimen name="messages_padding_left">72dp</dimen>
-    <dimen name="icon_width_height">40dp</dimen>
-    <dimen name="msg_text_primary">16sp</dimen>
-    <dimen name="msg_text_secondary">14sp</dimen>
-    <dimen name="icon_star">25dp</dimen>
-    <dimen name="icon_text">22dp</dimen>
-    <dimen name="timestamp">12dp</dimen>
-    <dimen name="scan_laser_width">4dp</dimen>
-    <dimen name="scan_dot_size">8dp</dimen>
-    <dimen name="btn_width">314dp</dimen>
-    <dimen name="btn_height">50dp</dimen>
-    <dimen name="text_title">18sp</dimen>
+	<!-- Default screen margins, per the Android Design guidelines. -->
+	<dimen name="activity_horizontal_margin">16dp</dimen>
+	<dimen name="activity_vertical_margin">16dp</dimen>
+	<dimen name="nav_header_vertical_spacing">12dp</dimen>
+	<dimen name="nav_header_height">160dp</dimen>
+	<dimen name="fab_margin">16dp</dimen>
+	<dimen name="padding_list_row">16dp</dimen>
+	<dimen name="messages_padding_left">72dp</dimen>
+	<dimen name="icon_width_height">40dp</dimen>
+	<dimen name="msg_text_primary">16sp</dimen>
+	<dimen name="msg_text_secondary">14sp</dimen>
+	<dimen name="icon_star">25dp</dimen>
+	<dimen name="icon_text">22dp</dimen>
+	<dimen name="timestamp">12dp</dimen>
+	<dimen name="scan_laser_width">4dp</dimen>
+	<dimen name="scan_dot_size">8dp</dimen>
+	<dimen name="btn_width">314dp</dimen>
+	<dimen name="btn_height">50dp</dimen>
+	<dimen name="text_title">18sp</dimen>
 
-    <!-- Tutorial -->
-    <dimen name="dots_height">30dp</dimen>
-    <dimen name="dots_bottom_margin">20dp</dimen>
-    <dimen name="img_width">120dp</dimen>
-    <dimen name="img_height">120dp</dimen>
-    <dimen name="slide_title">30sp</dimen>
-    <dimen name="slide_desc">16sp</dimen>
-    <dimen name="desc_padding">40dp</dimen>
+	<!-- Tutorial -->
+	<dimen name="dots_height">30dp</dimen>
+	<dimen name="dots_bottom_margin">20dp</dimen>
+	<dimen name="pager_height">50dp</dimen>
+
 </resources>


### PR DESCRIPTION
Complete refactoring of original PIVX welcome and tutorial screens. They doesn't work well on low and high resolution devices and don't support localized texts with different length. It is obvious for multi-language interfaces that they differ in size. With this PR we fully support mdpi, hdpi, xhdpi, xxhdpi and xxxhdpi. Also most of the `<RelativeLayout>` has been replaced with simpler and faster `<LinearLayout>` definition. The buttons include proper padding to support longer captions, words like *Skip* are *Überspringen* in German, this looks weird as seen in #2.