### PR TITLE
Improvements to local currency data fetching

### DIFF
--- a/app/src/main/java/galilel/org/galilelwallet/module/GalilelContext.java
+++ b/app/src/main/java/galilel/org/galilelwallet/module/GalilelContext.java
@@ -28,9 +28,6 @@ public class GalilelContext {
     // wallet released time.
     public static final long GALI_WALLET_APP_RELEASED_ON_PLAY_STORE_TIME = 1566381600;
 
-    // Currency exchange rate.
-    public static final String URL_FIAT_CURRENCIES_RATE = "https://bitpay.com/rates";
-
     // Report e-mail.
     public static final String REPORT_EMAIL = "maik.broemme@galilel.org";
 

--- a/app/src/main/java/galilel/org/galilelwallet/module/GalilelContext.java
+++ b/app/src/main/java/galilel/org/galilelwallet/module/GalilelContext.java
@@ -19,11 +19,13 @@ public class GalilelContext {
     public static final Context CONTEXT = new Context(NETWORK_PARAMETERS);
 
     public static final String DEFAULT_RATE_COIN = "USD";
-    public static final long RATE_UPDATE_TIME = 72000000;
+
+    // wallet update time of local currency rates (86400000 = every 24 hours).
+    public static final long RATE_UPDATE_TIME = 86400000;
 
     public static final String ENABLE_BIP44_APP_VERSION = "1.03";
 
-    // Galilel wallet released time.
+    // wallet released time.
     public static final long GALI_WALLET_APP_RELEASED_ON_PLAY_STORE_TIME = 1566381600;
 
     // Currency exchange rate.


### PR DESCRIPTION
It is enough to update the local currency database once a day or when the wallet is started and last update is older than 1 day.

The URL_FIAT_CURRENCIES_RATE constant is never used and it is better to populate it in its own class for additional API providers which might be added in future. Currently this affects only BitPay API provider.