### PR TITLE
More user reported bug fixes and removal of hardcoded colors

### DIFF
--- a/app/src/main/java/galilel/org/galilelwallet/ui/backup_mnemonic_activity/MnemonicActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/backup_mnemonic_activity/MnemonicActivity.java
@@ -1,8 +1,8 @@
 package galilel.org.galilelwallet.ui.backup_mnemonic_activity;
 
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -66,7 +66,7 @@ public class MnemonicActivity extends BaseActivity {
             FlexboxLayout.LayoutParams llp = new FlexboxLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
             llp.setMargins(0, 40, 20, 0);
             textView.setLayoutParams(llp);
-            textView.setTextColor(Color.BLACK);
+            textView.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack));
             textView.setBackgroundResource(R.drawable.bg_button_grey);
             textView.setPadding(10,8,10,8);
             textView.setText(word);

--- a/app/src/main/java/galilel/org/galilelwallet/ui/base/BaseRecyclerFragment.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/base/BaseRecyclerFragment.java
@@ -1,7 +1,7 @@
 package galilel.org.galilelwallet.ui.base;
 
-import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -147,7 +147,7 @@ public abstract class BaseRecyclerFragment<T> extends BaseFragment {
                             } else {
                                 showEmptyScreen();
                                 txt_empty.setText(emptyText);
-                                txt_empty.setTextColor(Color.BLACK);
+                                txt_empty.setTextColor(ContextCompat.getColor(getContext(), R.color.galilelBlack));
                             }
                         }
                     }

--- a/app/src/main/java/galilel/org/galilelwallet/ui/pincode_activity/PincodeActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/pincode_activity/PincodeActivity.java
@@ -2,8 +2,8 @@ package galilel.org.galilelwallet.ui.pincode_activity;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -56,7 +56,7 @@ public class PincodeActivity extends BaseActivity implements KeyboardFragment.on
         i4 = (ImageView) findViewById(R.id.imageview_circle4);
         keyboardFragment = (KeyboardFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_keyboard);
         keyboardFragment.setOnKeyListener(this);
-        keyboardFragment.setTextButtonsColor(Color.WHITE);
+        keyboardFragment.setTextButtonsColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelWhite));
     }
 
     private void goNext() {

--- a/app/src/main/java/galilel/org/galilelwallet/ui/settings_backup_activity/SettingsBackupActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/settings_backup_activity/SettingsBackupActivity.java
@@ -154,7 +154,7 @@ public class SettingsBackupActivity extends BaseActivity {
                         onBackPressed();
                     }
                 });
-                succedDialog.show(getFragmentManager(),getString(R.string.backup_succed_dialog));
+                succedDialog.show(getFragmentManager(),"backup_succed_dialog");
             }
         });
 

--- a/app/src/main/java/galilel/org/galilelwallet/ui/start_node_activity/StartNodeActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/start_node_activity/StartNodeActivity.java
@@ -2,10 +2,10 @@ package galilel.org.galilelwallet.ui.start_node_activity;
 
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
@@ -137,7 +137,7 @@ public class StartNodeActivity extends BaseActivity {
             @Override
             public View getDropDownView(int position, View convertView, ViewGroup parent) {
                 CheckedTextView view = (CheckedTextView) super.getDropDownView(position, convertView, parent);
-                view.setTextColor(Color.BLACK);
+                view.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack));
                 view.setPadding(16, 16, 16, 16);
                 return view;
             }
@@ -146,7 +146,7 @@ public class StartNodeActivity extends BaseActivity {
             @Override
             public View getView(int position, View convertView, ViewGroup parent) {
                 CheckedTextView view = (CheckedTextView) super.getView(position, convertView, parent);
-                view.setTextColor(Color.BLACK);
+                view.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack));
                 view.setPadding(8, 8, 8, 8);
                 return view;
             }

--- a/app/src/main/java/galilel/org/galilelwallet/ui/transaction_send_activity/SendActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/transaction_send_activity/SendActivity.java
@@ -2,7 +2,6 @@ package galilel.org.galilelwallet.ui.transaction_send_activity;
 
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
@@ -467,10 +466,10 @@ public class SendActivity extends BaseActivity implements View.OnClickListener {
                     }
             );
             noConnectivityDialog.setRightBtnTextColor(ContextCompat.getColor(getApplicationContext(), R.color.darkBrown1));
-            noConnectivityDialog.setLeftBtnTextColor(Color.WHITE)
-                    .setRightBtnTextColor(Color.BLACK)
-                    .setRightBtnBackgroundColor(Color.WHITE)
-                    .setLeftBtnTextColor(Color.BLACK)
+            noConnectivityDialog.setLeftBtnTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelWhite))
+                    .setRightBtnTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack))
+                    .setRightBtnBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelWhite))
+                    .setLeftBtnTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack))
                     .setLeftBtnText(getString(R.string.button_cancel))
                     .setRightBtnText(getString(R.string.button_ok))
                     .show();

--- a/app/src/main/java/galilel/org/galilelwallet/ui/transaction_send_activity/custom/outputs/MultipleOutputsFragment.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/transaction_send_activity/custom/outputs/MultipleOutputsFragment.java
@@ -2,7 +2,6 @@ package galilel.org.galilelwallet.ui.transaction_send_activity.custom.outputs;
 
 import android.support.v4.content.ContextCompat;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -118,7 +117,7 @@ public class MultipleOutputsFragment extends BaseRecyclerFragment<OutputWrapper>
                 if (data.getAddress()!=null){
                     holder.edit_address.setText(data.getAddress());
                     if (!galilelModule.chechAddress(data.getAddress())) {
-                        holder.edit_address.setTextColor(Color.RED);
+                        holder.edit_address.setTextColor(ContextCompat.getColor(getContext(), R.color.walletWarning));
                     } else {
                         holder.edit_address.setTextColor(ContextCompat.getColor(getContext(), R.color.grey85black));
                     }
@@ -152,7 +151,7 @@ public class MultipleOutputsFragment extends BaseRecyclerFragment<OutputWrapper>
                             if (holder.edit_address!=null) {
                                 String address = s.toString();
                                 if (!galilelModule.chechAddress(address)) {
-                                    holder.edit_address.setTextColor(Color.RED);
+                                    holder.edit_address.setTextColor(ContextCompat.getColor(getContext(), R.color.walletWarning));
                                 } else {
                                     holder.edit_address.setTextColor(ContextCompat.getColor(getContext(), R.color.grey85black));
                                     // check if there is a label for this address

--- a/app/src/main/java/galilel/org/galilelwallet/ui/wallet_activity/TransactionsFragmentBase.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/wallet_activity/TransactionsFragmentBase.java
@@ -1,7 +1,6 @@
 package galilel.org.galilelwallet.ui.wallet_activity;
 
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
@@ -102,7 +101,6 @@ public class TransactionsFragmentBase extends BaseRecyclerFragment<TransactionWr
                 holder.description.setText(data.getTransaction().getMemo());
 
                 if (data.isSent()) {
-                    //holder.cv.setBackgroundColor(Color.RED);Color.BROWN
                     holder.imageView.setImageResource(R.mipmap.ic_transaction_send);
                     holder.amount.setTextColor(ContextCompat.getColor(getContext(), R.color.walletInputSend));
                     holder.amount.setText("-" + holder.amount.getText());

--- a/app/src/main/java/galilel/org/galilelwallet/ui/wallet_activity/WalletActivity.java
+++ b/app/src/main/java/galilel/org/galilelwallet/ui/wallet_activity/WalletActivity.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
@@ -210,7 +209,7 @@ public class WalletActivity extends BaseDrawerActivity {
                         }
                 );
                 reminderDialog.setLeftBtnText(getString(R.string.button_dismiss));
-                reminderDialog.setLeftBtnTextColor(Color.BLACK);
+                reminderDialog.setLeftBtnTextColor(ContextCompat.getColor(getApplicationContext(), R.color.galilelBlack));
                 reminderDialog.setRightBtnText(getString(R.string.button_ok));
                 reminderDialog.show();
             }

--- a/app/src/main/java/galilel/org/galilelwallet/utils/DialogsUtil.java
+++ b/app/src/main/java/galilel/org/galilelwallet/utils/DialogsUtil.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
@@ -43,8 +42,8 @@ public class DialogsUtil {
         final SimpleTextDialog dialog = SimpleTextDialog.newInstance();
         dialog.setTitle(title);
         dialog.setBody(body);
-        dialog.setOkBtnBackgroundColor(Color.RED);
-        dialog.setOkBtnTextColor(Color.WHITE);
+        dialog.setOkBtnBackgroundColor(ContextCompat.getColor(context, R.color.walletWarning));
+        dialog.setOkBtnTextColor(ContextCompat.getColor(context, R.color.galilelWhite));
         dialog.setRootBackgroundRes(R.drawable.dialog_bg);
         return dialog;
     }
@@ -54,7 +53,7 @@ public class DialogsUtil {
         dialog.setTitle(title);
         dialog.setBody(body);
         dialog.setOkBtnBackgroundColor(ContextCompat.getColor(context, R.color.darkBrown1));
-        dialog.setOkBtnTextColor(Color.WHITE);
+        dialog.setOkBtnTextColor(ContextCompat.getColor(context, R.color.galilelWhite));
         dialog.setRootBackgroundRes(R.drawable.dialog_bg);
         return dialog;
     }
@@ -66,14 +65,14 @@ public class DialogsUtil {
     public static SimpleTwoButtonsDialog buildSimpleTwoBtnsDialog(Context context, String title, String body, SimpleTwoButtonsDialog.SimpleTwoBtnsDialogListener simpleTwoBtnsDialogListener){
         final SimpleTwoButtonsDialog dialog = SimpleTwoButtonsDialog.newInstance(context);
         dialog.setTitle(title);
-        dialog.setTitleColor(Color.BLACK);
+        dialog.setTitleColor(ContextCompat.getColor(context, R.color.galilelBlack));
         dialog.setBody(body);
-        dialog.setBodyColor(Color.BLACK);
+        dialog.setBodyColor(ContextCompat.getColor(context, R.color.galilelBlack));
         dialog.setListener(simpleTwoBtnsDialogListener);
-        dialog.setContainerBtnsBackgroundColor(Color.WHITE);
+        dialog.setContainerBtnsBackgroundColor(ContextCompat.getColor(context, R.color.galilelWhite));
         dialog.setRightBtnBackgroundColor(ContextCompat.getColor(context, R.color.darkBrown1));
-        dialog.setLeftBtnTextColor(Color.BLACK);
-        dialog.setRightBtnTextColor(Color.WHITE);
+        dialog.setLeftBtnTextColor(ContextCompat.getColor(context, R.color.galilelBlack));
+        dialog.setRightBtnTextColor(ContextCompat.getColor(context, R.color.galilelWhite));
         dialog.setRootBackgroundRes(R.drawable.dialog_bg);
         return dialog;
     }

--- a/app/src/main/java/galilel/org/galilelwallet/utils/ReportIssueDialogBuilder.java
+++ b/app/src/main/java/galilel/org/galilelwallet/utils/ReportIssueDialogBuilder.java
@@ -20,9 +20,9 @@ package galilel.org.galilelwallet.utils;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.graphics.Color;
 import android.net.Uri;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -88,7 +88,7 @@ public abstract class ReportIssueDialogBuilder extends DialogBuilder implements 
         setView(view);
         setPositiveButton(R.string.report_issue_dialog_report, this);
         setNegativeButton(R.string.button_cancel, null);
-        setTitleColor(Color.BLACK);
+        setTitleColor(ContextCompat.getColor(context, R.color.galilelBlack));
 
     }
 

--- a/app/src/main/res/layout/base_recycler_fragment.xml
+++ b/app/src/main/res/layout/base_recycler_fragment.xml
@@ -16,7 +16,7 @@
             android:id="@+id/recycler_contacts"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
             android:scrollbars="vertical" />
 
         <LinearLayout

--- a/app/src/main/res/layout/simple_dialog.xml
+++ b/app/src/main/res/layout/simple_dialog.xml
@@ -56,6 +56,7 @@
         android:layout_height="40dp"
         android:id="@+id/btn_ok"
         android:gravity="center"
+        android:text="@string/button_ok"
         android:textColor="@color/galilelWhite"
         android:background="@color/walletWarning" />
 

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -1,6 +1,0 @@
-<resources>
-    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
-         (such as screen margins) for screens with more than 820dp of available width. This
-         would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
-    <dimen name="activity_horizontal_margin">64dp</dimen>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,5 +290,4 @@
 
     <!-- internal strings, never translate. -->
     <string name="appbar_scrolling_view_behavior" translatable="false">appbar_scrolling_view_behavior</string>
-    <string name="backup_succed_dialog" translatable="false">backup_succed_dialog</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,7 +287,4 @@
     <string name="watch_only_mode_activated">Watch only mode activated</string>
     <string name="watch_only_mode_activated_text">Please wait until the synchronization is completed, could take a while be patient.</string>
     <string name="write_external_denied">Permission denied to write in the external storage</string>
-
-    <!-- internal strings, never translate. -->
-    <string name="appbar_scrolling_view_behavior" translatable="false">appbar_scrolling_view_behavior</string>
 </resources>


### PR DESCRIPTION
The missing "Ok" button is now shown in backup and restore dialogs. It fixes #17 and #18. Also the hardcoded colors have been replaced with proper values from `colors.xml` and the `values-w820dp` has been removed. It is usually auto generated by Android Studio and not explicitly used.